### PR TITLE
Fix output for birthday collision

### DIFF
--- a/Chapter1-Fundamentals.ipynb
+++ b/Chapter1-Fundamentals.ipynb
@@ -155,7 +155,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Compute the probability that no collision occurs if $k$ samples are drawn from a set of $n$ elements."
+    "Compute the probability that a collision occurs if $k$ samples are drawn from a set of $n$ elements."
    ]
   },
   {

--- a/Chapter1-Fundamentals.ipynb
+++ b/Chapter1-Fundamentals.ipynb
@@ -168,7 +168,7 @@
     "    p=1\n",
     "    for i in range(1,k):\n",
     "        p=p*(1-i/n)\n",
-    "    print(RR(p))"
+    "    print(1-RR(p))"
    ]
   },
   {
@@ -187,7 +187,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.492702765676015\n"
+      "0.507297234323985\n"
      ]
     }
    ],


### PR DESCRIPTION
The probability for birthday(1,365) needs to be 0%, without this patch
it is 100%.